### PR TITLE
Refactor Ownable into a bespoke "conductor

### DIFF
--- a/contracts/Orchestrated.sol
+++ b/contracts/Orchestrated.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.7.0;
-import "@openzeppelin/contracts/access/Ownable.sol";
 
 
 /**
@@ -11,26 +10,53 @@ import "@openzeppelin/contracts/access/Ownable.sol";
  * Once deployment is completed, `owner` should call `transferOwnership(address(0))` to avoid any more contracts ever gaining privileged access.
  */
 
-contract Orchestrated is Ownable {
+contract Orchestrated {
     event GrantedAccess(address access);
+    event TransferredConductor(address indexed oldConductor, address indexed newConductor);
 
+    address public conductor;
     mapping(address => mapping (bytes4 => bool)) public orchestration;
 
-    constructor () Ownable() {}
+    /// @dev Resrict usage to the conductor.
+    modifier onlyConductor() {
+        require(conductor == msg.sender, "Orchestrated: ");
+        _;
+    }
 
     /// @dev Restrict usage to authorized users
-    /// @param err The error to display if the validation fails 
+    /// @param err The error to display if the validation fails
     modifier onlyOrchestrated(string memory err) {
         require(orchestration[msg.sender][msg.sig], err);
         _;
+    }
+
+    /// @dev Initializes the contract setting the deployer as the initial conductor.
+    constructor() {
+        conductor = msg.sender;
     }
 
     /// @dev Add orchestration
     /// @param user Address of user or contract having access to this contract.
     /// @param signature bytes4 signature of the function we are giving orchestrated access to.
     /// It seems to me a bad idea to give access to humans, and would use this only for predictable smart contracts.
-    function orchestrate(address user, bytes4 signature) public onlyOwner {
+    function orchestrate(address user, bytes4 signature) external onlyConductor {
         orchestration[user][signature] = true;
         emit GrantedAccess(user);
+    }
+
+    /// @dev Leaves the contract without conductor, so it will not be possible to call
+    /// `onlyConductor` functions anymore. Can only be called by the current conductor.
+    function renounceConductor() external onlyConductor {
+        emit TransferredConductor(conductor, address(0x00));
+        conductor = address(0x00);
+    }
+
+    /// @dev Transfers the conductor of the contract to a new account (`newConductor`).
+    /// Can only be called by the current conductor.
+    /// @param newConductor The acount of the new conductor.
+    function transferConductor(address newConductor) external onlyConductor {
+        require(newConductor != address(0x00), "Orchestrator: Zero Address");
+        emit TransferredConductor(conductor, newConductor);
+        conductor = newConductor;
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -621,7 +621,7 @@
 
 "@openzeppelin/contracts@3.1.0-solc-0.7":
   version "3.1.0-solc-0.7"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.1.0-solc-0.7.tgz#c6c937d402abaefd2d541178e4c0b1131bf06b9f"
+  resolved "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.1.0-solc-0.7.tgz#c6c937d402abaefd2d541178e4c0b1131bf06b9f"
   integrity sha512-b3DjBHKn74XC9spvQEmn6t7dRZRN7pkeZ9IlDzkMgib09FUE3CDpKmtFCIUDYSLd8lkgSmB9Ig7Chctg8GWUiA==
 
 "@openzeppelin/test-helpers@^0.5.6":


### PR DESCRIPTION
Nice work! I've read the [article](https://hackernoon.com/identifying-smart-contract-orchestration-patterns-in-solidity-pd223x20) related to this repo and I think it's a very elegant implementation for a smart contract-oriented access control system.

I was thinking that there are cases where users may want to inherit from both `Ownable` and `Orchestrated`. Imagine there are functions that let the owner withdraw the earnings generated by the protocol - the owner would never want to renounce ownership on such a contract.

This PR re-implements the `Ownable.sol` logic natively in `Orchestrated.sol`, but it changes `owner` and `onlyOwnable` to `conductor` and `onlyConductor` - to better fit the theme here :D.